### PR TITLE
세션 관련 오류 수정

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -105,6 +105,10 @@ DefaultPlatformService=Steam
 [OnlineSubsystemSteam]
 bEnabled=true
 SteamDevAppId=480
+bEnableOverlay=true
+bUseSteamNetworking=true
+bAllowP2PPacketRelay=true
+bEnableSteamVoice=true
 
 ; If using Sessions
 ; bInitServerOnClient=true

--- a/Content/GameModes/BP_GameInstance.uasset
+++ b/Content/GameModes/BP_GameInstance.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf657c3aed2d940069362fed2a56d1d77af557ebfe3b98e2b1da32bbd684f5fc
-size 46982
+oid sha256:527bc9d5a21b0955761d8bc5a64f1d6c678c8fe7867bd2710c3446f6415cb17f
+size 46451

--- a/Content/UI/WBP_CreateGameUI.uasset
+++ b/Content/UI/WBP_CreateGameUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47b2bbe6608ed9ff6e6f224f56a343bdf7aad728a88527ce64f2603f8b79691c
-size 113862
+oid sha256:e4f17897f08ca9ab401ca253f7b8ea7f0fc277f80f2de2a5d7f9451c4955fa5c
+size 129575

--- a/Content/UI/WBP_GameSessionCard.uasset
+++ b/Content/UI/WBP_GameSessionCard.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b91998bd7c36fb672e24efe1425591aaa97762843528cbf731668997e5734451
-size 101644
+oid sha256:a91631b97eb3acf1ca656932d87ccb4693ffdf6a66943a315d94caa2f1a88dc6
+size 98924

--- a/Content/UI/WBP_LobbyListUI.uasset
+++ b/Content/UI/WBP_LobbyListUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b677325074d0e6e380c1155fa523708033c33e1d09db3867afc8b4a97fa9fe47
-size 107621
+oid sha256:054fffcd4e16290540c5bfda447e19ad10f7db2ed02bcff43217a2434631fe91
+size 117055

--- a/Source/Zone064/Private/BlueprintFunctionLibrary/ZNSessionLibrary.cpp
+++ b/Source/Zone064/Private/BlueprintFunctionLibrary/ZNSessionLibrary.cpp
@@ -1,0 +1,283 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "BlueprintFunctionLibrary/ZNSessionLibrary.h"
+#include "OnlineSubsystem.h"
+#include "OnlineSessionSettings.h"
+#include "Interfaces/OnlineSessionInterface.h"
+#include "Kismet/GameplayStatics.h"
+#include "Engine/Engine.h"
+#include "GameModes/ZNSessionGameInstance.h"
+#include "GameFramework/GameStateBase.h"
+
+FString UZNSessionLibrary::GenerateUniqueSessionName(UObject* WorldContextObject)
+{
+    FString Timestamp = FDateTime::Now().ToString(TEXT("%Y%m%d%H%M%S"));
+    FString NameString = FString::Printf(TEXT("Game_%s"), *Timestamp);
+    FName SessionName = FName(*NameString);
+
+    if (UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject))
+    {
+        if (UZNSessionGameInstance* GI = World->GetGameInstance<UZNSessionGameInstance>())
+        {
+            GI->CurrentSessionName = SessionName;
+        }
+    }
+
+    return NameString;
+}
+
+void UZNSessionLibrary::SafeDestroySession(UObject* WorldContextObject)
+{
+    IOnlineSubsystem* Subsystem = IOnlineSubsystem::Get();
+    if (!Subsystem) return;
+
+    IOnlineSessionPtr Session = Subsystem->GetSessionInterface();
+    if (!Session.IsValid()) return;
+
+    if (UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject))
+    {
+        if (UZNSessionGameInstance* GI = World->GetGameInstance<UZNSessionGameInstance>())
+        {
+            if (Session->GetNamedSession(GI->CurrentSessionName))
+            {
+                Session->DestroySession(GI->CurrentSessionName);
+            }
+        }
+    }
+}
+
+FName UZNSessionLibrary::GetCurrentSessionName(UObject* WorldContextObject)
+{
+    if (UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject))
+    {
+        if (UZNSessionGameInstance* GI = World->GetGameInstance<UZNSessionGameInstance>())
+        {
+            return GI->CurrentSessionName;
+        }
+    }
+
+    return NAME_None;
+}
+
+TArray<FBlueprintSessionResult> UZNSessionLibrary::FilterValidSessions(const TArray<FBlueprintSessionResult>& SessionResults)
+{
+    TArray<FBlueprintSessionResult> ValidResults;
+
+    for (const FBlueprintSessionResult& SessionResult : SessionResults)
+    {
+        const FOnlineSessionSearchResult& NativeResult = SessionResult.OnlineResult;
+        const auto& Session = NativeResult.Session;
+
+        IOnlineSubsystem* Subsystem = IOnlineSubsystem::Get();
+        TSharedPtr<const FUniqueNetId> MyUniqueNetId;
+
+        if (Subsystem)
+        {
+            IOnlineIdentityPtr IdentityInterface = Subsystem->GetIdentityInterface();
+            if (IdentityInterface.IsValid())
+            {
+                MyUniqueNetId = IdentityInterface->GetUniquePlayerId(0);
+            }
+        }
+
+        if (!NativeResult.IsValid())
+        {
+            continue;
+        }
+
+        if (Session.OwningUserName.IsEmpty())
+        {
+            continue;
+        }
+
+        int32 MaxPlayers = Session.SessionSettings.NumPublicConnections;
+        int32 OpenPlayers = Session.NumOpenPublicConnections;
+        int32 CurrentPlayers = MaxPlayers - OpenPlayers;
+        if (MaxPlayers <= 0 || CurrentPlayers < 0 || CurrentPlayers > MaxPlayers)
+        {
+            continue;
+        }
+
+        FString GameName;
+        if (!Session.SessionSettings.Get(TEXT("GameName"), GameName) || GameName.IsEmpty())
+        {
+            continue;
+        }
+
+        if (MyUniqueNetId.IsValid() &&
+            NativeResult.Session.OwningUserId.IsValid() &&
+            *NativeResult.Session.OwningUserId == *MyUniqueNetId)
+        {
+            continue;
+        }
+
+        ValidResults.Add(SessionResult);
+    }
+
+    return ValidResults;
+}
+
+bool UZNSessionLibrary::CreateFullSession(UObject* WorldContextObject, int32 MaxPlayers, const FString& GameName)
+{
+    IOnlineSubsystem* Subsystem = IOnlineSubsystem::Get();
+    if (!Subsystem) return false;
+
+    IOnlineSessionPtr SessionInterface = Subsystem->GetSessionInterface();
+    if (!SessionInterface.IsValid()) return false;
+
+    FOnlineSessionSettings Settings;
+    Settings.NumPublicConnections = MaxPlayers;
+    Settings.bShouldAdvertise = true;
+    Settings.bUsesPresence = true;
+    Settings.bAllowJoinViaPresence = true;
+    Settings.bAllowJoinInProgress = true;
+    Settings.bAllowInvites = true;
+    Settings.bIsLANMatch = false;
+
+    Settings.bUseLobbiesIfAvailable = true;
+    // 보이스 쳇
+    Settings.bUseLobbiesVoiceChatIfAvailable = true;
+    Settings.bAllowJoinViaPresenceFriendsOnly = false;
+    Settings.bIsDedicated = false;
+    Settings.bUsesStats = false;
+    Settings.bAntiCheatProtected = false;
+
+    // ExtraSetting: UI에 표시될 방 이름
+    Settings.Set(TEXT("GameName"), GameName, EOnlineDataAdvertisementType::ViaOnlineServiceAndPing);
+
+    Settings.Set(FName("CURRENT_PLAYERS"), 1, EOnlineDataAdvertisementType::ViaOnlineServiceAndPing);
+
+    // 세션 생성
+    if (UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject))
+    {
+        if (APlayerController* PC = World->GetFirstPlayerController())
+        {
+            if (ULocalPlayer* LP = PC->GetLocalPlayer())
+            {
+                FUniqueNetIdRepl NetID = LP->GetPreferredUniqueNetId();
+                if (NetID.IsValid())
+                {
+                    return SessionInterface->CreateSession(*NetID, GetCurrentSessionName(WorldContextObject), Settings);
+                }
+                else
+                {
+                    UE_LOG(LogTemp, Warning, TEXT("CreateFullSession: NetID is invalid."));
+                }
+            }
+        }
+    }
+
+    UE_LOG(LogTemp, Warning, TEXT("CreateFullSession: Failed to get World/PC/LocalPlayer."));
+    return false;
+}
+
+bool UZNSessionLibrary::JoinNamedSession(UObject* WorldContextObject, const FBlueprintSessionResult& SearchResult)
+{
+    if (!SearchResult.OnlineResult.IsValid())
+    {
+        UE_LOG(LogTemp, Warning, TEXT("JoinNamedSession: Invalid session result"));
+        return false;
+    }
+
+    IOnlineSubsystem* Subsystem = IOnlineSubsystem::Get();
+    if (!Subsystem) return false;
+
+    IOnlineSessionPtr Sessions = Subsystem->GetSessionInterface();
+    if (!Sessions.IsValid()) return false;
+
+    // Get the current session name from GameInstance
+    FName SessionName = NAME_GameSession;
+    if (UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject))
+    {
+        if (UZNSessionGameInstance* GI = World->GetGameInstance<UZNSessionGameInstance>())
+        {
+            SessionName = GetCurrentSessionName(WorldContextObject);
+        }
+
+        if (APlayerController* PC = World->GetFirstPlayerController())
+        {
+            FUniqueNetIdRepl NetID = PC->GetLocalPlayer()->GetPreferredUniqueNetId();
+            if (NetID.IsValid())
+            {
+                Sessions->AddOnJoinSessionCompleteDelegate_Handle(
+                    FOnJoinSessionCompleteDelegate::CreateLambda([=](FName JoinedName, EOnJoinSessionCompleteResult::Type Result)
+                        {
+                            if (Result == EOnJoinSessionCompleteResult::Success)
+                            {
+                                FString ConnectString;
+                                if (Sessions->GetResolvedConnectString(JoinedName, ConnectString))
+                                {
+                                    PC->ClientTravel(ConnectString, TRAVEL_Absolute);
+                                }
+                            }
+                            else
+                            {
+                                UE_LOG(LogTemp, Warning, TEXT("JoinNamedSession: Join failed."));
+                            }
+                        })
+                );
+
+                return Sessions->JoinSession(*NetID, SessionName, SearchResult.OnlineResult);
+            }
+        }
+    }
+
+    return false;
+}
+
+void UZNSessionLibrary::TemporarilyDisableButton(UButton* TargetButton, float DisableDuration)
+{
+    if (!TargetButton || DisableDuration <= 0.f) return;
+
+    TargetButton->SetIsEnabled(false);
+
+    if (UWorld* World = TargetButton->GetWorld())
+    {
+        TWeakObjectPtr<UButton> WeakButton = TargetButton;
+
+        FTimerDelegate TimerCallback;
+        TimerCallback.BindLambda([WeakButton]()
+            {
+                if (WeakButton.IsValid())
+                {
+                    WeakButton->SetIsEnabled(true);
+                }
+            });
+
+        FTimerHandle TimerHandle;
+        World->GetTimerManager().SetTimer(TimerHandle, TimerCallback, DisableDuration, false);
+    }
+}
+
+FText UZNSessionLibrary::GetFormattedSessionPlayerCount(const FBlueprintSessionResult& SessionResult)
+{
+    int32 MaxPlayers = SessionResult.OnlineResult.Session.SessionSettings.NumPublicConnections;
+    int32 CurrentPlayers = 0;
+
+    SessionResult.OnlineResult.Session.SessionSettings.Get(FName("CURRENT_PLAYERS"), CurrentPlayers);
+
+    return FText::FromString(FString::Printf(TEXT("%d / %d"), CurrentPlayers, MaxPlayers));
+}
+
+void UZNSessionLibrary::UpdatePlayerCountInSession(UObject* WorldContextObject, int32 Delta)
+{
+    if (!WorldContextObject) return;
+
+    IOnlineSubsystem* Subsystem = IOnlineSubsystem::Get();
+    if (!Subsystem) return;
+
+    IOnlineSessionPtr SessionInterface = Subsystem->GetSessionInterface();
+    if (!SessionInterface.IsValid()) return;
+
+    FNamedOnlineSession* Session = SessionInterface->GetNamedSession(NAME_GameSession);
+    if (!Session) return;
+
+    int32 CurrentPlayers = 1;
+    Session->SessionSettings.Get(FName("CURRENT_PLAYERS"), CurrentPlayers);
+
+    CurrentPlayers = FMath::Clamp(CurrentPlayers + Delta, 0, Session->SessionSettings.NumPublicConnections);
+    Session->SessionSettings.Set(FName("CURRENT_PLAYERS"), CurrentPlayers, EOnlineDataAdvertisementType::ViaOnlineServiceAndPing);
+
+    SessionInterface->UpdateSession(NAME_GameSession, Session->SessionSettings, true);
+}

--- a/Source/Zone064/Private/GameModes/ZNInGameGameMode.cpp
+++ b/Source/Zone064/Private/GameModes/ZNInGameGameMode.cpp
@@ -1,8 +1,33 @@
 #include "GameModes/ZNInGameGameMode.h"
-
+#include "Kismet/GameplayStatics.h"
+#include "BlueprintFunctionLibrary/ZNSessionLibrary.h"
 #include "Controllers/ZNPlayerController.h"
 
 AZNInGameGameMode::AZNInGameGameMode()
 {
 	PlayerControllerClass = AZNPlayerController::StaticClass();
+}
+
+void AZNInGameGameMode::HandleStartingNewPlayer_Implementation(APlayerController* NewPlayer)
+{
+    Super::HandleStartingNewPlayer_Implementation(NewPlayer);
+
+    if (GEngine)
+    {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Yellow, TEXT("인원 +1"));
+    }
+
+    UZNSessionLibrary::UpdatePlayerCountInSession(this, +1);
+}
+
+void AZNInGameGameMode::Logout(AController* Exiting)
+{
+    Super::Logout(Exiting);
+
+    if (GEngine)
+    {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Yellow, TEXT("인원 -1"));
+    }
+
+    UZNSessionLibrary::UpdatePlayerCountInSession(this, -1);
 }

--- a/Source/Zone064/Private/GameModes/ZNSessionGameInstance.cpp
+++ b/Source/Zone064/Private/GameModes/ZNSessionGameInstance.cpp
@@ -1,0 +1,21 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GameModes/ZNSessionGameInstance.h"
+
+#include "OnlineSubsystem.h"
+#include "Interfaces/OnlineSessionInterface.h"
+
+void UZNSessionGameInstance::Shutdown()
+{
+	IOnlineSessionPtr SessionInterface = Online::GetSessionInterface(GetWorld());
+	if (SessionInterface.IsValid())
+	{
+		if (SessionInterface->GetNamedSession(NAME_GameSession))
+		{
+			UE_LOG(LogTemp, Warning, TEXT("UZNSessionGameInstance::Shutdown - Destroying active session."));
+			SessionInterface->DestroySession(NAME_GameSession);
+		}
+	}
+	Super::Shutdown();
+}

--- a/Source/Zone064/Public/BlueprintFunctionLibrary/ZNSessionLibrary.h
+++ b/Source/Zone064/Public/BlueprintFunctionLibrary/ZNSessionLibrary.h
@@ -1,0 +1,54 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "BlueprintDataDefinitions.h"
+#include "Components/Button.h"
+#include "ZNSessionLibrary.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ZONE064_API UZNSessionLibrary : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+    // 고유한 세션 이름 생성 + GameInstance에 저장
+    UFUNCTION(BlueprintCallable, Category = "Session", meta = (WorldContext = "WorldContextObject"))
+    static FString GenerateUniqueSessionName(UObject* WorldContextObject);
+
+    // 저장된 세션 이름 기반 세션 제거
+    UFUNCTION(BlueprintCallable, Category = "Session", meta = (WorldContext = "WorldContextObject"))
+    static void SafeDestroySession(UObject* WorldContextObject);
+
+    // 저장된 세션 이름 조회
+    UFUNCTION(BlueprintCallable, Category = "Session", meta = (WorldContext = "WorldContextObject"))
+    static FName GetCurrentSessionName(UObject* WorldContextObject);
+
+    // 세션 필터링
+    UFUNCTION(BlueprintCallable, Category = "Session")
+    static TArray<FBlueprintSessionResult> FilterValidSessions(const TArray<FBlueprintSessionResult>& SessionResults);
+
+    // 세션 생성
+    UFUNCTION(BlueprintCallable, meta = (WorldContext = "WorldContextObject"))
+    static bool CreateFullSession(UObject* WorldContextObject, int32 MaxPlayers, const FString& GameName);
+
+    // 세션 참가
+    UFUNCTION(BlueprintCallable, meta = (WorldContext = "WorldContextObject"))
+    static bool JoinNamedSession(UObject* WorldContextObject, const FBlueprintSessionResult& SearchResult);
+
+    // 버튼 연속 클릭 방지
+    UFUNCTION(BlueprintCallable, Category = "UI|Utils")
+    static void TemporarilyDisableButton(UButton* TargetButton, float DisableDuration = 1.0f);
+
+    // 세션 인원수 적용
+    UFUNCTION(BlueprintPure, Category = "Session")
+    static FText GetFormattedSessionPlayerCount(const FBlueprintSessionResult& SessionResult);
+
+    UFUNCTION(BlueprintCallable, Category = "Session")
+    static void UpdatePlayerCountInSession(UObject* WorldContextObject, int32 Delta);
+};

--- a/Source/Zone064/Public/GameModes/ZNInGameGameMode.h
+++ b/Source/Zone064/Public/GameModes/ZNInGameGameMode.h
@@ -12,4 +12,7 @@ class ZONE064_API AZNInGameGameMode : public AGameMode
 	
 public:
 	AZNInGameGameMode();
+
+	virtual void HandleStartingNewPlayer_Implementation(APlayerController* NewPlayer) override;
+	virtual void Logout(AController* Exiting) override;
 };

--- a/Source/Zone064/Public/GameModes/ZNSessionGameInstance.h
+++ b/Source/Zone064/Public/GameModes/ZNSessionGameInstance.h
@@ -1,0 +1,23 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AdvancedFriendsGameInstance.h"
+#include "ZNSessionGameInstance.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ZONE064_API UZNSessionGameInstance : public UAdvancedFriendsGameInstance
+{
+	GENERATED_BODY()
+	
+public:
+
+	UPROPERTY(BlueprintReadWrite)
+	FName CurrentSessionName;
+
+	virtual void Shutdown() override;
+};

--- a/Source/Zone064/Zone064.Build.cs
+++ b/Source/Zone064/Zone064.Build.cs
@@ -1,5 +1,6 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
+using System.IO;
 using UnrealBuildTool;
 
 public class Zone064 : ModuleRules
@@ -8,16 +9,17 @@ public class Zone064 : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG" });
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "UMG", "OnlineSubsystem", "OnlineSubsystemUtils"});
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 
-		// Uncomment if you are using Slate UI
-		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
-		
-		// Uncomment if you are using online features
-		// PrivateDependencyModuleNames.Add("OnlineSubsystem");
+        DynamicallyLoadedModuleNames.Add("OnlineSubsystemSteam");
+        // Uncomment if you are using Slate UI
+        // PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
 
-		// To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
-	}
+        // Uncomment if you are using online features
+        // PrivateDependencyModuleNames.Add("OnlineSubsystem");
+
+        // To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
+    }
 }

--- a/Zone064.uproject
+++ b/Zone064.uproject
@@ -9,7 +9,8 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
 			"AdditionalDependencies": [
-				"Engine"
+				"Engine",
+				"AdvancedSessions"
 			]
 		}
 	],


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력해 주세요.
  2. 명확하게 질문하고 명확하게 답변해 주세요.
 -->

 ## 💻 작업사항 
<!-- PR내용에 대해 상세 설명이 필요하다면 이 부분에 기재해 주세요. -->
  -
미해결 문제
핑 문제

Steam은 기본적으로 P2P 기반이라 세션 검색 시 호스트의 정확한 네트워크 정보를 알 수 없음
인원 수 표시

이것 또한 P2P와 스팀에서 지원을 안해주기에 여러 방법으로 시도
많은 시간을 투자했던 것은 아쉽지만 추후에 수정하고 싶음 -> 개인적으로 인원 수 표시는 하고싶었음
수정한 문제
세션 생성 -> 고정된 세션 이름 -> 하드코딩되어있어 수정 불가능 -> 새롭게 함수로 만들어 세션 생성
세션 참가 -> 마찬가지로 고정된 세션이름으로 참가 -> ''
세션 제거 코드 추가

세션이름을 다르게 하는 이유

서버가 꺼지거나 비정상 종료되었을 때, 같은 이름으로 세션을 다시 생성하려 하면 "이미 존재"하는 세션으로 인식되어 실패할 수 있음
동일한 이름으로 재생성 시 과거 세션 정보가 노출되거나 이상 동작이 발생할 수 있음
세션 필터링

세션이 살아있는지 / 호스트가 존재하는지 / 세션에 방이름이 존재하는지 등등을 판단하여 세션을 보여줌
버튼 2회 이상 클릭 방지 코드 추가

클릭이 우연히 여러번 될 경우 세션이 추가 생성될 수 있음

 ## 💡Issue 번호
<!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close 